### PR TITLE
refines safe resize function

### DIFF
--- a/site/plugins/safe-resize/index.php
+++ b/site/plugins/safe-resize/index.php
@@ -3,16 +3,20 @@
 use Kirby\Cms\App;
 // plugin to safely resize images and return null if the image is missing (for optional image fields)
 App::plugin('earthrise/safe-resize', [
-  'fileMethods' => [
+  'fieldMethods' => [
     /**
      * @kql-allowed
      */
-    'safeResize' => function (int $width = 1200, int $height = null, array $options = []) {
-      if (!$this) {
+    'safeResize' => function ($field, $width = 1200) {
+      if (!$field) {
         return null; // field empty -> return null
       }
 
-      $thumb = $this->resize($width, $height, $options);
+      if (!$field->toFile()) {
+        return null; // not a file -> return null
+      }
+
+      $thumb = $field->toFile()->resize($width);
 
       if (!$thumb) {
         return null; // resize failed -> return null
@@ -22,7 +26,6 @@ App::plugin('earthrise/safe-resize', [
         'url'    => $thumb->url(),
         'width'  => $thumb->width(),
         'height' => $thumb->height(),
-        'alt'    => $this->alt()->or(''),
       ];
     }
   ]


### PR DESCRIPTION
sets up safeResize field method that can be called on image fields to resize the image if it exists, and return null otherwise.