### PR TITLE
renames 'tags' field to 'taxonomy' for people pages

### DIFF
--- a/site/blueprints/pages/person.yml
+++ b/site/blueprints/pages/person.yml
@@ -90,4 +90,4 @@ tabs:
     label: Tags
     icon: tag
     fields:
-      tags: fields/tags
+      taxonomy: fields/tags


### PR DESCRIPTION
Normalizes name of tags field across all page types to support new tag query card feed on frontend