### PR TITLE
adds page type for Articles

### DIFF
--- a/site/blueprints/pages/article.yml
+++ b/site/blueprints/pages/article.yml
@@ -1,0 +1,50 @@
+title: Article
+tabs:
+  main:
+    label: Main Content
+    icon: book
+    columns:
+      - width: 2/3
+        sections:
+          content:
+            type: fields
+            fields:
+              text: fields/ec-blocks
+
+      - width: 1/3
+        sections:
+          meta:
+            type: fields
+            fields:
+              author:
+                type: pages
+                max: 4
+                query: site.find('people').children
+                template: person
+              hero:
+                label: Hero Image
+                type: files
+                layout: cards
+                max: 1
+                image:
+                  cover: true
+                uploads:
+                  template: image
+              license:
+                type: select
+                label: License
+                options:
+                  - CC BY
+                  - CC BY-NC
+                default: CC BY-NC
+              remixSource:
+                label: Remix Source
+                help: Select a chapter or lesson this content is based on.
+                type: pages
+                max: 1
+                query: kirby.collection('remixable')
+  tags:
+    label: Tags
+    icon: tag
+    fields:
+      taxonomy: fields/tags

--- a/site/blueprints/pages/articles.yml
+++ b/site/blueprints/pages/articles.yml
@@ -1,0 +1,18 @@
+title: Articles
+options:
+  delete: false
+  changeSlug: false
+  changeTitle: false
+  changeStatus: false
+  changeTemplate: false
+
+sections:
+  people:
+    type: pages
+    search: true
+    headline: Articles
+    templates:
+      - article
+    create: true
+    layout: cardlets
+    info: "{{page.author.toPage.displayName}}"

--- a/site/blueprints/site.yml
+++ b/site/blueprints/site.yml
@@ -33,3 +33,12 @@ sections:
     search: true
     templates:
       - lesson
+  article:
+    type: pages
+    label: "Articles ({{kirby.page('articles').children.count}})"
+    parent: kirby.page("articles")
+    layout: cardlets
+    info: "{{page.author.toPage.displayName}}"
+    search: true
+    templates:
+      - article


### PR DESCRIPTION
Adds a page type for Articles, that is currently identical to the Lessons page type. This should be compatible with the articles filter that is currently in development on the frontend